### PR TITLE
Fix cnlp_annotate when given tif input.

### DIFF
--- a/R/annotate.R
+++ b/R/annotate.R
@@ -77,8 +77,6 @@ cnlp_annotate <- function(input,
       stop(sprintf("text_var variable '%s' not found in input", text_var))
     }
 
-    input <- input[[text_var]]
-
     # grab document ids
     if (!is.null(doc_var)) {
       if (doc_var %in% names(input)) {
@@ -101,6 +99,7 @@ cnlp_annotate <- function(input,
       meta <- input[,-non_meta_cols,drop=FALSE]
     }
 
+    input <- input[[text_var]]
     as_strings <- TRUE
   }
 
@@ -196,6 +195,3 @@ cnlp_quick <- function(input, ...) {
 
   return(df)
 }
-
-
-


### PR DESCRIPTION
cnlp_annotate works when given `as_strings = TRUE`, but not for tif input. Using the example code in the README gives this error:

```
library(cleanNLP)
text <- c("It is better to be looked over than overlooked.",
         "Real stupidity beats artificial intelligence every time.",
         "The secret of getting ahead is getting started.")
tif_input <- data.frame(doc_id = c("West", "Pratchett", "Twain"),
                        text = text,
                        stringsAsFactors = FALSE)
cnlp_init_udpipe()
obj <- cnlp_annotate(tif_input)
  ...
Error in if (length(non_meta_cols) < ncol(input)) { :
  argument is of length zero
```

This is because `input <- input[[text_var]]` happens before input is interrogated for meta data columns. Moving this to below the metadata processing fixes the issue. 
