### PR TITLE
empty strings giving an error for coreNLP backend fixed

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,5 @@
 ^CONTRIBUTING.md$
 ^docs
 ^vignettes
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cleanNLP
 Type: Package
 Title: A Tidy Data Model for Natural Language Processing
-Version: 3.0.1
+Version: 3.0.2
 Authors@R: c(person(given = "Taylor B.", family = "Arnold", email = "taylor.arnold@acm.org", role = c("aut", "cre")))
 Author: Taylor B. Arnold [aut, cre]
 Maintainer: Taylor B. Arnold <taylor.arnold@acm.org>

--- a/R/backend_corenlp.R
+++ b/R/backend_corenlp.R
@@ -10,8 +10,18 @@ annotate_with_corenlp <- function(input, verbose) {
     x <- input$text[i]
     doc_id <- input$doc_id[i]
 
-    z <- volatiles$corenlp$obj$parseDocument(x, doc_id)
-    token[[i]] <- as.data.frame(z$token, stringsAsFactors=FALSE)
+  if(length(x)!=0){
+            z <- volatiles$corenlp$obj$parseDocument(x, doc_id)
+            token[[i]] <- as.data.frame(z$token, stringsAsFactors=FALSE)
+        } else {
+            ## mimics the structure but removes the text
+            z <- volatiles$corenlp$obj$parseDocument("-", doc_id)
+            token[[i]] <- as.data.frame(z$token, stringsAsFactors=FALSE)[-1,] 
+        }
+
+        cmsg(verbose, "Processed document %d of %d\n", i, nrow(input))
+    }
+
 
     cmsg(verbose, "Processed document %d of %d\n", i, nrow(input))
   }

--- a/R/backend_corenlp.R
+++ b/R/backend_corenlp.R
@@ -21,10 +21,7 @@ annotate_with_corenlp <- function(input, verbose) {
 
         cmsg(verbose, "Processed document %d of %d\n", i, nrow(input))
     }
-
-
-    cmsg(verbose, "Processed document %d of %d\n", i, nrow(input))
-  }
+   
 
   anno <- list()
   anno$token <- structure(do.call("rbind", token),

--- a/R/backend_corenlp.R
+++ b/R/backend_corenlp.R
@@ -10,7 +10,7 @@ annotate_with_corenlp <- function(input, verbose) {
     x <- input$text[i]
     doc_id <- input$doc_id[i]
 
-  if(length(x)!=0){
+  if(x != ""){
             z <- volatiles$corenlp$obj$parseDocument(x, doc_id)
             token[[i]] <- as.data.frame(z$token, stringsAsFactors=FALSE)
         } else {

--- a/R/init.R
+++ b/R/init.R
@@ -162,8 +162,7 @@ cnlp_init_corenlp <- function(lang=NULL, models_dir=NULL, config=NULL) {
 
   volatiles$corenlp$obj <- volatiles$cleannlp$corenlp$corenlpCleanNLP(
     volatiles$corenlp$lang,
-    volatiles$corenlp$models_dir,
-    volatiles$corenlp$config
+    volatiles$corenlp$models_dir
   )
   volatiles$corenlp$init <- TRUE
   volatiles$model_init_last <- "corenlp"


### PR DESCRIPTION
It fixes #61 
Not sure if the other backends present the same problems. 
And by the way, the github version had an extra line (in comparison to the cran version) adding an extra argument `config` to `volatiles$cleannlp$corenlp$corenlpCleanNLP`.
 I had to remove that so that  `cnlp_init_corenlp()` works.
